### PR TITLE
Add terraform variables to configure chrony on coreos

### DIFF
--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -89,9 +89,12 @@ locals {
         rhcos_kernel_options    = var.rhcos_kernel_options
         sysctl_tuned_options    = var.sysctl_tuned_options
         sysctl_options          = var.sysctl_options
+        chrony_config           = var.chrony_config
+        chrony_config_servers   = var.chrony_config_servers
         match_array             = indent(2,var.match_array)
         proxy_url               = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
         no_proxy                = var.cidr
+        
     }
 
     upgrade_vars = {

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -94,7 +94,6 @@ locals {
         match_array             = indent(2,var.match_array)
         proxy_url               = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
         no_proxy                = var.cidr
-        
     }
 
     upgrade_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -23,5 +23,15 @@ match_array:
   ${match_array}
 %{endif ~}
 
+%{ if chrony_config ~}
+chronyconfig:
+  enabled: true
+  content:
+%{ for item in chrony_config_servers ~}
+    - server: ${item.server}
+      options: ${item.options}
+%{ endfor ~}
+%{endif ~}
+
 proxy_url: "${proxy_url}"
 no_proxy: "${no_proxy}"

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -67,6 +67,8 @@ variable "rhcos_kernel_options" {}
 
 variable "sysctl_tuned_options" {}
 variable "sysctl_options" {}
+variable "chrony_config" { default = false }
+variable "chrony_config_servers" {}
 variable "match_array" {}
 
 variable proxy {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -118,6 +118,8 @@ module "install" {
     rhcos_kernel_options            = var.rhcos_kernel_options
     sysctl_tuned_options            = var.sysctl_tuned_options
     sysctl_options                  = var.sysctl_options
+    chrony_config                   = var.chrony_config
+    chrony_config_servers           = var.chrony_config_servers
     match_array                     = var.match_array
     proxy                           = var.proxy
     upgrade_image                   = var.upgrade_image

--- a/var.tfvars
+++ b/var.tfvars
@@ -56,6 +56,8 @@ sysctl_tuned_options  = false
 #- label: disk
 #  value: ssd
 #EOF
+chrony_config = false
+#chrony_config_servers = [ {server = "0.centos.pool.ntp.org", options = "iburst"}, {server = "1.centos.pool.ntp.org", options = "iburst"} ]
 
 #helpernode_tag = "5eab3db53976bb16be582f2edc2de02f7510050d"
 #install_playbook_tag = "374a19ab0e4ba279cbb5f9406bf63ea1e88a5c3e"

--- a/variables.tf
+++ b/variables.tf
@@ -211,7 +211,7 @@ variable "helpernode_tag" {
 variable "install_playbook_tag" {
     description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
     # Checkout level for https://github.com/ocp-power-automation/ocp4-playbooks which is used for running ocp4 installations steps
-    default = "374a19ab0e4ba279cbb5f9406bf63ea1e88a5c3e"
+    default = "22f883869be8aaf9e470301a24796a20e7782d37"
 }
 
 variable "ansible_extra_options" {

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,25 @@ variable "match_array" {
 EOF
 }
 
+variable "chrony_config" {
+    description = "Set to true to setup time synchronization and setup chrony. Default: false"
+    default     = false
+}
+
+variable "chrony_config_servers" {
+    description = "List of ntp servers and options to apply"
+    default     = [
+        {
+            server = "0.centos.pool.ntp.org",
+            options = "iburst"
+        }, 
+        {
+            server = "1.centos.pool.ntp.org", 
+            options = "iburst"
+        } 
+    ]
+}
+
 ################################################################
 ### Instrumentation
 ################################################################


### PR DESCRIPTION
Create terraform variables in order to configure chrony (ntp) on coreOS node.

This is related to changes in ocp4-playbook project (commit 22f883869be8aaf9e470301a24796a20e7782d37)
issue : https://github.com/ocp-power-automation/ocp4-playbooks/issues/31
PR: https://github.com/ocp-power-automation/ocp4-playbooks/pull/34 

creation of to variable:
  `chrony_config`: true or false (default)
  `chrony_config_servers`: list of ntp server and options
  
terraform variable usage example
```
chrony_config = true
chrony_config_servers = [ {server = "0.centos.pool.ntp.org", options = "iburst"}, {server = "1.centos.pool.ntp.org", options = "iburst"} ]
```