### PR TITLE
Use hostnames instead of IP in inventory

### DIFF
--- a/modules/3_helpernode/templates/helpernode_vars.yaml
+++ b/modules/3_helpernode/templates/helpernode_vars.yaml
@@ -1,7 +1,7 @@
 ---
 disk: vda
 helper:
-  name: "helper"
+  name: "${cluster_id}-bastion"
   ipaddr: "${bastion_ip}"
 dns:
   domain: "${cluster_domain}"

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -24,10 +24,10 @@ locals {
     ocp_release_repo    = "ocp4/openshift4"
 
     inventory = {
-        bastion_ip      = var.bastion_ip
-        bootstrap_ip    = var.bootstrap_ip
-        master_ips      = var.master_ips
-        worker_ips      = var.worker_ips
+        bastion_host    = "${var.cluster_id}-bastion"
+        bootstrap_host  = "bootstrap"
+        master_hosts    = [for ix in range(length(var.master_ips)) : "master-${ix}"]
+        worker_hosts    = [for ix in range(length(var.worker_ips)) : "worker-${ix}"]
     }
 
     proxy = {

--- a/modules/5_install/templates/inventory
+++ b/modules/5_install/templates/inventory
@@ -1,15 +1,15 @@
 [bastion]
-${bastion_ip} ansible_connection=local
+${bastion_host} ansible_connection=ssh ansible_user=root
 
 [bootstrap]
-${bootstrap_ip} ansible_connection=ssh ansible_user=core
+${bootstrap_host} ansible_connection=ssh ansible_user=core
 
 [masters]
-%{ for master in master_ips ~}
+%{ for master in master_hosts ~}
 ${master} ansible_connection=ssh ansible_user=core
 %{ endfor ~}
 
 [workers]
-%{ for worker in worker_ips ~}
+%{ for worker in worker_hosts ~}
 ${worker} ansible_connection=ssh ansible_user=core
 %{ endfor ~}


### PR DESCRIPTION
This will help show hosts as hostnames instead of IP addresses in Ansible console. Good to understand the log messages related to specific nodes.

Fixes #163

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>
