### PR TITLE
Add variable to set default CNI network provider

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -209,3 +209,9 @@ upgrade_image              = ""  #(e.g. `"quay.io/openshift-release-dev/ocp-rele
 upgrade_pause_time         = "90"
 upgrade_delay_time         = "600"
 ```
+
+This variable is used to set the default Container Network Interface (CNI) network provider such as OpenShiftSDN or OVNKubernetes
+
+```
+cni_network_provider       = "OpenshiftSDN"
+```

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -59,6 +59,7 @@ locals {
         chrony_config           = var.chrony_config
         chrony_config_servers   = var.chrony_config_servers
         chrony_allow_range      = var.cidr
+        cni_network_provider    = var.cni_network_provider
     }
 
     upgrade_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -48,3 +48,5 @@ no_proxy: "${no_proxy}"
 
 # This flag when true/yes will allow sharing same network for multiple dhcp servers
 dhcp_shared_network: true
+
+cni_network_provider: "${cni_network_provider}"

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -69,3 +69,5 @@ variable "upgrade_channel" {}
 variable "upgrade_image" {}
 variable "upgrade_pause_time" {}
 variable "upgrade_delay_time" {}
+
+variable "cni_network_provider" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -165,4 +165,5 @@ module "install" {
     upgrade_delay_time              = var.upgrade_delay_time
     chrony_config                   = var.chrony_config
     chrony_config_servers           = var.chrony_config_servers
+    cni_network_provider            = var.cni_network_provider
 }

--- a/var.tfvars
+++ b/var.tfvars
@@ -80,3 +80,5 @@ cluster_id                  = ""
 #upgrade_image               = "" #quay.io/openshift-release-dev/ocp-release@sha256:xyz.."
 #upgrade_pause_time         = "90"
 #upgrade_delay_time         = "600"
+
+#cni_network_provider       = "OpenshiftSDN"

--- a/variables.tf
+++ b/variables.tf
@@ -231,7 +231,7 @@ variable "install_playbook_repo" {
 variable "install_playbook_tag" {
     description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
     # Checkout level for https://github.com/ocp-power-automation/ocp4-playbooks which is used for running ocp4 installations steps
-    default = "eeabfb1c83a4ecc8980dd09261a3a849cb4448fb"
+    default = "592e51671ff2762718955fb2a0541a5b19c862e9"
 }
 
 variable "ansible_extra_options" {
@@ -346,6 +346,11 @@ variable "upgrade_pause_time" {
 variable "upgrade_delay_time" {
     description = "Number of seconds to wait before re-checking the upgrade status once the playbook execution resumes."
     default = "600"
+}
+
+variable "cni_network_provider" {
+    description = "Set the default Container Network Interface (CNI) network provider"
+    default = "OpenshiftSDN"
 }
 
 ################################################################


### PR DESCRIPTION
The default cni network provider can be set for deployment via the networkType variable in the install-config. The values can be OpenshiftSDN or OVNKubernetes.

Signed-off-by: Pravin Dsilva <pravin.d-silva@ibm.com>

