### PR TITLE
Fix Ansible install on CentOS

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -219,7 +219,6 @@ EOF
 }
 
 resource "null_resource" "enable_repos" {
-    count       = ( var.rhel_subscription_username == "" || var.rhel_subscription_username  == "<subscription-id>" ) && var.rhel_subscription_org == "" ? 0 : 1
     depends_on      = [null_resource.bastion_init, null_resource.setup_proxy_info, null_resource.bastion_register]
 
     connection {

--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -174,9 +174,6 @@ resource "null_resource" "bastion_register" {
     provisioner "remote-exec" {
         inline = [<<EOF
 
-# FIX for existing stale repos
-echo 'Moving all file from /etc/yum.repos.d/ to /etc/yum.repos.d.bak/'
-mkdir /etc/yum.repos.d.bak/ && mv /etc/yum.repos.d/* /etc/yum.repos.d.bak/
 # Give some more time to subscription-manager
 sudo subscription-manager config --server.server_timeout=600
 sudo subscription-manager clean


### PR DESCRIPTION
1. Fix Ansible install on CentOS 
2. Removed stale repo fix as this stale repos is on the user creating the image. Since most of the resources have fresh image we should not have this.

Fixes #174

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>