### PR TITLE
Add availability-zone as optinal attribute for OCP cluster nodes, Fix #179

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -51,6 +51,15 @@ worker                      = {instance_type    = "<worker-compute-template>", i
 You can optionally set worker `count` value to 0 in which case all the cluster pods will be running on the master/supervisor nodes. 
 Ensure you use proper sizing for master/supervisor nodes to avoid resource starvation for containers.
 
+`availability_zone` is an optional attribute for bastion, bootstrap, master and worker. If it is specified, the VM will be created in the specified `availability_zone`, otherwise value of `openstack_availability_zone` will be used. 
+```
+bastion                     = {instance_type    = "<bastion-compute-template>", image_id    = "<image-uuid-rhel>"}
+bootstrap                   = {instance_type    = "<bootstrap-compute-template>", image_id    = "<image-uuid-rhcos>", availability_zone = "", "count"   = 1}
+master                      = {instance_type    = "<master-compute-template>", image_id    = "<image-uuid-rhcos>", availability_zone = "master-zone",  "count"   = 3}
+worker                      = {instance_type    = "<worker-compute-template>", image_id    = "<image-uuid-rhcos>", availability_zone = "worker-zone",  "count"   = 2}
+```
+Above will create the bastion in `openstack_availability_zone`, bootstrap in default availability zone, masters in `master-zone`, and workers in `worker-zone`.
+
 To set a pre-defined IPv4 address for the bastion node, make use of the optional `fixed_ip_v4` in bastion variable as shown below. Ensure this address is within the given network subnet range and not already in use.
 ```
 bastion                     = {instance_type    = "<bastion-compute-template>", image_id    = "<image-uuid-rhel>",  fixed_ip_v4 = "<IPv4 address>"}

--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -55,7 +55,7 @@ resource "openstack_compute_instance_v2" "bastion" {
         name        = var.network_name
         fixed_ip_v4 = local.fixed_ip_v4
     }
-    availability_zone = var.openstack_availability_zone
+    availability_zone = lookup(var.bastion, "availability_zone", var.openstack_availability_zone)
 }
 
 locals {

--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -66,7 +66,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     name        = "${var.cluster_id}-bootstrap"
     flavor_id   = var.scg_id == "" ? data.openstack_compute_flavor_v2.bootstrap.id : openstack_compute_flavor_v2.bootstrap_scg[0].id
     image_id    = var.bootstrap["image_id"]
-    availability_zone   = var.openstack_availability_zone
+    availability_zone   = lookup(var.bootstrap, "availability_zone", var.openstack_availability_zone)
 
     user_data   = replace(data.ignition_config.bootstrap.rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}")
 
@@ -127,7 +127,7 @@ resource "openstack_compute_instance_v2" "master" {
     count       = var.master["count"]
     flavor_id   = var.scg_id == "" ? data.openstack_compute_flavor_v2.master.id : openstack_compute_flavor_v2.master_scg[0].id
     image_id    = var.master["image_id"]
-    availability_zone   = var.openstack_availability_zone
+    availability_zone   = lookup(var.master, "availability_zone", var.openstack_availability_zone)
 
     user_data   = replace(data.ignition_config.master[count.index].rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}")
 
@@ -182,7 +182,7 @@ resource "openstack_compute_instance_v2" "worker" {
     count       = var.worker["count"]
     flavor_id   = var.scg_id == "" ? data.openstack_compute_flavor_v2.worker.id : openstack_compute_flavor_v2.worker_scg[0].id
     image_id    = var.worker["image_id"]
-    availability_zone   = var.openstack_availability_zone
+    availability_zone   = lookup(var.worker, "availability_zone", var.openstack_availability_zone)
 
     user_data = replace(data.ignition_config.worker[count.index].rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}")
 

--- a/var.tfvars
+++ b/var.tfvars
@@ -11,10 +11,14 @@ network_name                = "<network_name>"
 ### OpenShift Cluster Details
 
 bastion                     = {instance_type    = "<bastion-compute-template>",   image_id    = "<image-uuid-rhel>"}
-# bastion                     = {instance_type    = "<bastion-compute-template>",   image_id    = "<image-uuid-rhel>",  fixed_ip_v4 = "<IPv4 address>"}
 bootstrap                   = {instance_type    = "<bootstrap-compute-template>", image_id    = "<image-uuid-rhcos>",  "count"   = 1}
 master                      = {instance_type    = "<master-compute-template>",    image_id    = "<image-uuid-rhcos>",  "count"   = 3}
 worker                      = {instance_type    = "<worker-compute-template>",    image_id    = "<image-uuid-rhcos>",  "count"   = 2}
+# With all optional attributes
+# bastion                     = {instance_type    = "<bastion-compute-template>",   image_id    = "<image-uuid-rhel>",  availability_zone = "<availability zone>", fixed_ip_v4 = "<IPv4 address>"}
+# bootstrap                   = {instance_type    = "<bootstrap-compute-template>", image_id    = "<image-uuid-rhcos>",  availability_zone = "<availability zone>",  "count"   = 1}
+# master                      = {instance_type    = "<master-compute-template>",    image_id    = "<image-uuid-rhcos>",  availability_zone = "<availability zone>",  "count"   = 3}
+# worker                      = {instance_type    = "<worker-compute-template>",    image_id    = "<image-uuid-rhcos>",  availability_zone = "<availability zone>",  "count"   = 2}
 
 
 rhel_username               = "root"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,8 @@ variable "bastion" {
     default = {
         instance_type   = "m1.xlarge"
         image_id        = "daa5d3f4-ab66-4b2d-9f3d-77bd61774419"
+        # optional availability_zone
+        # availability_zone = ""
         # optional fixed IP address
         # fixed_ip_v4   = "123.45.67.89"
     }
@@ -76,6 +78,8 @@ variable "bootstrap" {
         instance_type = "m1.xlarge"
         # rhcos image id
         image_id      = "468863e6-4b33-4e8b-b2c5-c9ef9e6eedf4"
+        # optional availability_zone
+        # availability_zone = ""
     }
 }
 
@@ -85,6 +89,8 @@ variable "master" {
         instance_type = "m1.xlarge"
         # rhcos image id
         image_id      = "468863e6-4b33-4e8b-b2c5-c9ef9e6eedf4"
+        # optional availability_zone
+        # availability_zone = ""
     }
 }
 
@@ -94,6 +100,8 @@ variable "worker" {
         instance_type = "m1.xlarge"
         # rhcos image id
         image_id      = "468863e6-4b33-4e8b-b2c5-c9ef9e6eedf4"
+        # optional availability_zone
+        # availability_zone = ""
     }
 }
 


### PR DESCRIPTION
Fix 179

 Add `availability_zone` as the optional attribute for OCP node : bastion, bootstrap, master and worker. If it is not specified the `openstack_availability_zone` will be used for them.
 
Signed-off-by: CS Zhang <zhangcho@us.ibm.com>