### PR TITLE
Support specify cluster_id without prefix, Fix #88

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -119,6 +119,7 @@ Set the `cluster_domain` to `nip.io`, `xip.io` or `sslip.io` if you prefer using
 Default is `ibm.com`.
 The `cluster_id_prefix` should not be more than 8 characters. Nodes are pre-fixed with this value.
 Default value is `test-ocp`
+If `cluster_if_prefix` is not set, the `cluster_id` will be used only without prefix.
 
 A random value will be used for `cluster_id` if not set.
 The total length of `cluster_id_prefix`.`cluster_id` should not exceed 14 characters.

--- a/ocp.tf
+++ b/ocp.tf
@@ -35,7 +35,7 @@ resource "random_id" "label" {
 
 locals {
     # Generates cluster_id as combination of cluster_id_prefix + (random_id or user-defined cluster_id)
-    cluster_id  = var.cluster_id == "" ? random_id.label[0].hex : "${var.cluster_id_prefix}-${var.cluster_id}"
+    cluster_id  = var.cluster_id == "" ? random_id.label[0].hex : (var.cluster_id_prefix == ""? var.cluster_id : "${var.cluster_id_prefix}-${var.cluster_id}")
 }
 
 module "bastion" {

--- a/var.tfvars
+++ b/var.tfvars
@@ -38,9 +38,9 @@ openshift_install_tarball   = "https://mirror.openshift.com/pub/openshift-v4/ppc
 openshift_client_tarball    = "https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp-dev-preview/latest/openshift-client-linux.tar.gz"
 pull_secret_file            = "data/pull-secret.txt"
 
-cluster_domain              = "ibm.com"  #Set domain to nip.io or xip.io if you prefer using online wildcard domain and avoid modifying /etc/hosts
-cluster_id_prefix           = "test-ocp"
-cluster_id                  = ""
+cluster_domain              = "ibm.com"  # Set domain to nip.io or xip.io if you prefer using online wildcard domain and avoid modifying /etc/hosts
+cluster_id_prefix           = "test-ocp" # Set it to empty if just want to use cluster_id without prefix
+cluster_id                  = ""         # It will use random generated id with cluster_id_prefix if this is not set
 
 
 ### Misc Customizations


### PR DESCRIPTION
Just use cloud_id if cloud_id_prefix is not set.

Signed-off-by: CS Zhang <zhangcho@us.ibm.com>