### PR TITLE
Timeout added while removing worker node

### DIFF
--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -217,7 +217,7 @@ resource "null_resource" "remove_worker" {
         on_failure  = continue
         inline = [<<EOF
 oc adm cordon worker-${count.index}
-oc adm drain worker-${count.index} --force --delete-local-data --ignore-daemonsets
+oc adm drain worker-${count.index} --force --delete-local-data --ignore-daemonsets --timeout=180s
 oc delete node worker-${count.index}
 EOF
         ]


### PR DESCRIPTION
Added 3 min wait for the drain command to complete. This will help when no worker nodes are left for scheduling non disruptive pods.

Fixes #203

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>