### PR TITLE
Implementation for #200

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -139,6 +139,18 @@ The following variable is used to set the network adapter type for the VMs. By d
 network_type                = "SRIOV"
 ```
 
+The following variable is used to define the amount of SR-IOV Virtual Functions used for VNIC failover of the network adapter for the VMs. By default the VMs will use 1, which defines `no VNIC failover`. Any setting higher then 1 creates additional virtual functions and configures them in a VNIC failover setup. `Be aware of the fact, that RHCOS and some Linux releases might not handle VNIC failover with more then 2 SR-IOV Virtual Functions properly. The recommended value is 2 for VNIC failover.`
+Valid options are: Any number supported for VNIC failover from 1 to 6
+```
+sriov_vnic_failover_vfs                = 1
+```
+
+The following variable is used to define the capacity of SR-IOV Logical Ports of the 1st network adapter for the VMs. By default the VMs will use 2%.
+Valid options are: Any number which can be devided by 2 and results in an integer. 100% = 1.0; 80% = 0.80; 60% = 0.60; etc
+```
+sriov_capacity                = 0.02
+```
+
 The following variable is used to specify the PowerVC [Storage Connectivity Group](https://www.ibm.com/support/knowledgecenter/SSVSPA_1.4.4/com.ibm.powervc.cloud.help.doc/powervc_storage_connectivity_groups_cloud.html) (SCG). Empty value will use the default SCG
 ```
 scg_id                      = ""

--- a/modules/2_network/network.tf
+++ b/modules/2_network/network.tf
@@ -126,8 +126,8 @@ locals {
    sriov   = <<EOF
    {
        "delete_with_instance": 1,
-       "vnic_required_vfs": 1,
-       "capacity": 0.02,
+       "vnic_required_vfs": ${var.sriov_vnic_failover_vfs},
+       "capacity": ${var.sriov_capacity},
        "vlan_type": "allowed"
    }
    EOF

--- a/modules/2_network/variables.tf
+++ b/modules/2_network/variables.tf
@@ -29,3 +29,5 @@ variable "master" {}
 variable "worker" {}
 
 variable "network_type" {}
+variable "sriov_vnic_failover_vfs" {}
+variable "sriov_capacity" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -79,6 +79,8 @@ module "network" {
     master                          = var.master
     worker                          = var.worker
     network_type                    = var.network_type
+    sriov_vnic_failover_vfs         = var.sriov_vnic_failover_vfs
+    sriov_capacity                  = var.sriov_capacity
 }
 
 module "helpernode" {

--- a/var.tfvars
+++ b/var.tfvars
@@ -47,7 +47,8 @@ cluster_id                  = ""         # It will use random generated id with 
 
 #network_type               = "SRIOV"
 #scg_id                     = "df21cec9-c244-4d3d-b927-df1518672e87"
-
+#sriov_vnic_failover_vfs    = 1
+#sriov_capacity             = 0.02
 
 #enable_local_registry      = false  #Set to true to enable usage of local registry for restricted network install.
 #local_registry_image       = "docker.io/ibmcom/registry-ppc64le:2.6.2.5"

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,22 @@ variable "network_type" {
     description = "Specify the name of the network adapter type to use for creating hosts"
 }
 
+variable "sriov_vnic_failover_vfs" {
+    # Eg: 1 = VNIC without failover; 2 = VNIC failover with 2 SR-IOV VFs
+    default = 1
+    description = "Specifies the amount of VNIC failover virtual functions (max. is 6)"
+    validation {
+        condition = var.sriov_vnic_failover_vfs > 0 && var.sriov_vnic_failover_vfs < 7
+        error_message = "The number of virtual functions for the parameter sriov_vnic_failover_vfs must be min. 1 and cannot exceed 6."
+    }
+}
+
+variable "sriov_capacity" {
+    # Eg: 0.02 = 2%; 0.20 = 20%; 1.00 = 100%
+    default = 0.02
+    description = "Specifies the SR-IOV LP capacity"
+}
+
 variable "scg_id" {
     description = "The id of PowerVC Storage Connectivity Group to use for all nodes"
     default = ""


### PR DESCRIPTION
This is a suggestion for the implementation of #200

I already implemented exactly this code at a customer. It introduces two new variables to var.tfvars to control how many logical ports shall be used for VNIC failover and also to define the capacity of the logical ports.

PS: This time I have everything in one commit.

Signed-off-by: Torsten Wendland <twendlan@de.ibm.com>