### PR TITLE
Allow using archive path for ocp4-helpernode and ocp4-playbooks

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - mkumatag
   - Prajyot-Parab
   - sudeeshjohn
   - yussufsh
@@ -7,4 +6,5 @@ reviewers:
   - cs-zhang
 approvers:
   - bpradipt
+  - cs-zhang
   - yussufsh

--- a/docs/automation_host_prereqs.md
+++ b/docs/automation_host_prereqs.md
@@ -22,7 +22,7 @@ Install the following packages on the automation host. Select the appropriate in
 **Terraform >= 0.13.0**: Please refer to the [link](https://learn.hashicorp.com/terraform/getting-started/install.html) for instructions on installing Terraform. For validating the version run `terraform version` command after install.
 
 Install Terraform and providers for Power environment:
-1. Download the Terraform binary version 0.13.5 from https://www.power-devops.com/terraform and install it to /usr/local/bin.
+1. Download and install the Terraform binary (>= 0.13.0) for Linux/ppc64le from https://www.power-devops.com/terraform.
 2. Download the required Terraform providers for Power into your TF project directory:
 ```
 $ cd <path_to_TF_project>

--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -93,18 +93,18 @@ resource "null_resource" "bastion_init" {
     }
     provisioner "file" {
         content = var.private_key
-        destination = "$HOME/.ssh/id_rsa"
+        destination = ".ssh/id_rsa"
     }
     provisioner "file" {
         content = var.public_key
-        destination = "$HOME/.ssh/id_rsa.pub"
+        destination = ".ssh/id_rsa.pub"
     }
     provisioner "remote-exec" {
         inline = [
-            "sudo chmod 600 $HOME/.ssh/id_rsa*",
+            "sudo chmod 600 .ssh/id_rsa*",
             "sudo sed -i.bak -e 's/^ - set_hostname/# - set_hostname/' -e 's/^ - update_hostname/# - update_hostname/' /etc/cloud/cloud.cfg",
-            "sudo hostnamectl set-hostname --static ${lower(var.cluster_id)}-bastion-${count.index}.${var.cluster_domain}",
-            "echo 'HOSTNAME=${lower(var.cluster_id)}-bastion-${count.index}.${var.cluster_domain}' | sudo tee -a /etc/sysconfig/network > /dev/null",
+            "sudo hostnamectl set-hostname --static ${lower(var.cluster_id)}-bastion-${count.index}.${lower(var.cluster_id)}.${var.cluster_domain}",
+            "echo 'HOSTNAME=${lower(var.cluster_id)}-bastion-${count.index}.${lower(var.cluster_id)}.${var.cluster_domain}' | sudo tee -a /etc/sysconfig/network > /dev/null",
             "sudo hostname -F /etc/hostname",
             "echo 'vm.max_map_count = 262144' | sudo tee --append /etc/sysctl.conf > /dev/null",
         ]
@@ -265,12 +265,12 @@ resource "null_resource" "bastion_packages" {
     provisioner "remote-exec" {
         inline = [
             "#sudo yum update -y --skip-broken",
-            "sudo yum install -y wget jq git net-tools vim python3 tar"
+            "sudo yum install -y wget jq git net-tools vim python3 tar curl unzip"
         ]
     }
     provisioner "remote-exec" {
         inline = [
-           "sudo yum install -y ansible"
+           "sudo yum install -y ansible-2.9.*"
         ]
     }
     provisioner "remote-exec" {
@@ -327,11 +327,11 @@ resource "null_resource" "setup_nfs_disk" {
     }
     provisioner "remote-exec" {
         inline = [
-            "rm -rf mkdir ${local.storage_path}; mkdir -p ${local.storage_path}; chmod -R 755 ${local.storage_path}",
+            "sudo rm -rf mkdir ${local.storage_path}; sudo mkdir -p ${local.storage_path}; sudo chmod -R 755 ${local.storage_path}",
             "sudo chmod +x /tmp/create_disk_link.sh",
             # Fix for copying file from Windows OS having CR
-            "sed -i 's/\r//g' /tmp/create_disk_link.sh",
-            "/tmp/create_disk_link.sh",
+            "sudo sed -i 's/\r//g' /tmp/create_disk_link.sh",
+            "sudo /tmp/create_disk_link.sh",
             "sudo mkfs.ext4 -F /dev/${local.disk_config.disk_name}",
             "echo '/dev/${local.disk_config.disk_name} ${local.storage_path} ext4 defaults 0 0' | sudo tee -a /etc/fstab > /dev/null",
             "sudo mount ${local.storage_path}",

--- a/modules/1_bastion/versions.tf
+++ b/modules/1_bastion/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }

--- a/modules/2_network/versions.tf
+++ b/modules/2_network/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 1.32"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }

--- a/modules/3_helpernode/templates/helpernode_inventory
+++ b/modules/3_helpernode/templates/helpernode_inventory
@@ -1,4 +1,4 @@
 [vmhost]
 %{ for ip in bastion_ip ~}
-${ip} ansible_connection=ssh ansible_user=root
+${ip} ansible_connection=ssh ansible_user=${rhel_username}
 %{ endfor ~}

--- a/modules/3_helpernode/templates/helpernode_vars.yaml
+++ b/modules/3_helpernode/templates/helpernode_vars.yaml
@@ -21,10 +21,16 @@ dns:
   domain: "${cluster_domain}"
   clusterid: "${cluster_id}"
   forwarder1: "${forwarders}"
+%{ if lb_ipaddr != "" }
+  lb_ipaddr: "${lb_ipaddr}"
+%{ endif }
 dhcp:
   router: "${gateway_ip}"
   bcast: "${broadcast}"
   netmask: "${netmask}"
+%{ if ext_dns != "" }
+  dns: "${ext_dns}"
+%{ endif }
   ipid: "${ipid}"
   netmaskid: "${netmask}"
   poolstart: "${pool.start}"
@@ -84,4 +90,4 @@ ocp_initramfs: "file:///dev/null"
 ocp_install_kernel: "file:///dev/null"
 
 # This is required for latest helpernode. TODO: Remove when https://github.com/RedHatOfficial/ocp4-helpernode/pull/140 is merged
-helm_source: "https://get.helm.sh/helm-v3.4.0-linux-ppc64le.tar.gz"
+helm_source: "${helm_repo}"

--- a/modules/3_helpernode/variables.tf
+++ b/modules/3_helpernode/variables.tf
@@ -29,6 +29,8 @@ variable "dns_forwarders" {
     default   = "8.8.8.8; 9.9.9.9"
 }
 
+variable "lb_ipaddr" {}
+variable "ext_dns" {}
 variable "gateway_ip" {}
 variable "cidr" {}
 variable "allocation_pools" {}
@@ -58,6 +60,7 @@ variable "ocp_release_tag" {}
 
 variable "helpernode_repo" {}
 variable "helpernode_tag" {}
+variable "helm_repo" {}
 
 variable "ansible_extra_options" {}
 

--- a/modules/3_helpernode/versions.tf
+++ b/modules/3_helpernode/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 2.1"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }

--- a/modules/5_install/templates/install_inventory
+++ b/modules/5_install/templates/install_inventory
@@ -1,6 +1,6 @@
 [bastion]
 %{ for bastion in bastion_hosts ~}
-${bastion} ansible_connection=ssh ansible_user=root
+${bastion} ansible_connection=ssh ansible_user=${rhel_username}
 %{ endfor ~}
 
 %{ if bootstrap_host != "" ~}

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -10,8 +10,11 @@ storage_type: ${storage_type}
 log_level: ${log_level}
 release_image_override: '${release_image_override}'
 enable_local_registry: ${enable_local_registry}
+fips_compliant: "${fips_compliant}"
 
 node_connection_timeout: ${node_connection_timeout}
+
+rhcos_pre_kernel_options: [%{ for opt in rhcos_pre_kernel_options ~}"${opt}",%{ endfor ~}]
 
 rhcos_kernel_options: [%{ for opt in rhcos_kernel_options ~}"${opt}",%{ endfor ~}]
 
@@ -54,3 +57,8 @@ bastion_vip: "${bastion_vip}"
 %{ endif ~}
 
 cni_network_provider: "${cni_network_provider}"
+
+cluster_network_cidr: "${cluster_network_cidr}"
+cluster_network_hostprefix: "${cluster_network_hostprefix}"
+service_network: "${service_network}"
+cni_network_mtu: "${cni_network_mtu}"

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -35,6 +35,7 @@ variable "ssh_agent" {}
 variable "connection_timeout" {}
 variable "jump_host" {}
 
+variable "bastion" {}
 variable "bootstrap_ip" {}
 variable "master_ips" {}
 variable "worker_ips" {}
@@ -42,6 +43,9 @@ variable "worker_ips" {}
 variable "public_key" {}
 variable "pull_secret" {}
 variable "release_image_override" {}
+variable "fips_compliant" {}
+
+variable "private_network_mtu" {}
 
 variable "enable_local_registry" {}
 variable "local_registry_image" {}
@@ -54,6 +58,7 @@ variable "storage_type" {}
 variable "log_level" {}
 
 variable "ansible_extra_options" {}
+variable "rhcos_pre_kernel_options" {}
 variable "rhcos_kernel_options" {}
 
 variable "sysctl_tuned_options" {}
@@ -72,3 +77,6 @@ variable "upgrade_pause_time" {}
 variable "upgrade_delay_time" {}
 
 variable "cni_network_provider" {}
+variable "cluster_network_cidr" {}
+variable "cluster_network_hostprefix" {}
+variable "service_network" {}

--- a/modules/5_install/versions.tf
+++ b/modules/5_install/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 2.1"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }

--- a/ocp.tf
+++ b/ocp.tf
@@ -88,6 +88,8 @@ module "helpernode" {
     cluster_domain                  = var.cluster_domain
     cluster_id                      = local.cluster_id
     dns_forwarders                  = var.dns_forwarders
+    lb_ipaddr                       = var.lb_ipaddr
+    ext_dns                         = var.ext_dns
     gateway_ip                      = module.network.gateway_ip
     cidr                            = module.network.cidr
     allocation_pools                = module.network.allocation_pools
@@ -111,6 +113,7 @@ module "helpernode" {
     ocp_release_tag                 = var.ocp_release_tag
     helpernode_repo                 = var.helpernode_repo
     helpernode_tag                  = var.helpernode_tag
+    helm_repo                       = var.helm_repo
     ansible_extra_options           = var.ansible_extra_options
     chrony_config                   = var.chrony_config
     chrony_config_servers           = var.chrony_config_servers
@@ -145,6 +148,7 @@ module "install" {
     cluster_domain                  = var.cluster_domain
     cluster_id                      = local.cluster_id
     cidr                            = module.network.cidr
+    bastion                         = var.bastion
     bastion_vip                     = module.network.bastion_vip
     bastion_ip                      = module.bastion.bastion_ip
     rhel_username                   = var.rhel_username
@@ -159,13 +163,16 @@ module "install" {
     pull_secret                     = file(coalesce(var.pull_secret_file, "/dev/null"))
     storage_type                    = local.storage_type
     release_image_override          = var.release_image_override
+    private_network_mtu             = var.private_network_mtu
     enable_local_registry           = var.enable_local_registry
+    fips_compliant                  = var.fips_compliant
     local_registry_image            = var.local_registry_image
     ocp_release_tag                 = var.ocp_release_tag
     install_playbook_repo           = var.install_playbook_repo
     install_playbook_tag            = var.install_playbook_tag
     log_level                       = var.installer_log_level
     ansible_extra_options           = var.ansible_extra_options
+    rhcos_pre_kernel_options        = var.rhcos_pre_kernel_options
     rhcos_kernel_options            = var.rhcos_kernel_options
     sysctl_tuned_options            = var.sysctl_tuned_options
     sysctl_options                  = var.sysctl_options
@@ -180,4 +187,7 @@ module "install" {
     chrony_config                   = var.chrony_config
     chrony_config_servers           = var.chrony_config_servers
     cni_network_provider            = var.cni_network_provider
+    cluster_network_cidr            = var.cluster_network_cidr
+    cluster_network_hostprefix      = var.cluster_network_hostprefix
+    service_network                 = var.service_network
 }

--- a/var.tfvars
+++ b/var.tfvars
@@ -21,7 +21,7 @@ worker                      = {instance_type    = "<worker-compute-template>",  
 # worker                      = {instance_type    = "<worker-compute-template>",    image_id    = "<image-uuid-rhcos>",  availability_zone = "<availability zone>",  "count"   = 2, data_volume_count  = 0, data_volume_size  = 100}
 
 
-rhel_username               = "root"
+rhel_username               = "root"  #Set it to an appropriate username for non-root user access
 public_key_file             = "data/id_rsa.pub"
 private_key_file            = "data/id_rsa"
 rhel_subscription_username  = "<subscription-id>"          #Leave this as-is if using CentOS as bastion image
@@ -41,7 +41,7 @@ pull_secret_file            = "data/pull-secret.txt"
 cluster_domain              = "ibm.com"  # Set domain to nip.io or xip.io if you prefer using online wildcard domain and avoid modifying /etc/hosts
 cluster_id_prefix           = "test-ocp" # Set it to empty if just want to use cluster_id without prefix
 cluster_id                  = ""         # It will use random generated id with cluster_id_prefix if this is not set
-
+#fips_compliant             = false   # Set it true if you prefer to use FIPS enable in ocp deployment
 
 ### Misc Customizations
 
@@ -61,11 +61,13 @@ cluster_id                  = ""         # It will use random generated id with 
 #helpernode_tag             = ""
 #install_playbook_repo      = "https://github.com/ocp-power-automation/ocp4-playbooks"
 #install_playbook_tag       = ""
+#helm_repo                 = "https://get.helm.sh/helm-v3.6.3-linux-ppc64le.tar.gz"
 
 #installer_log_level        = "info"
 #ansible_extra_options      = "-v"
 #ansible_repo_name          = "ansible-2.9-for-rhel-8-ppc64le-rpms"
 #dns_forwarders             = "1.1.1.1; 9.9.9.9"
+#rhcos_pre_kernel_options   = []
 #rhcos_kernel_options       = []
 #chrony_config              = true
 #chrony_config_servers      = [ {server = "0.centos.pool.ntp.org", options = "iburst"}, {server = "1.centos.pool.ntp.org", options = "iburst"} ]
@@ -90,3 +92,7 @@ cluster_id                  = ""         # It will use random generated id with 
 #upgrade_delay_time         = "600"
 
 #cni_network_provider       = "OpenshiftSDN"
+#cluster_network_cidr        = "10.128.0.0/14"
+#cluster_network_hostprefix  = "23"
+#service_network             = "172.30.0.0/16"
+#private_network_mtu         = "1450"

--- a/variables.tf
+++ b/variables.tf
@@ -199,6 +199,12 @@ variable "rhel_subscription_org" {
 variable "rhel_subscription_activationkey" {
     default = ""
 }
+
+variable "rhcos_pre_kernel_options" {
+    description = "List of kernel arguments for the cluster nodes for pre-installation"
+    default     = []
+}
+
 variable "rhcos_kernel_options" {
     description = "List of kernel arguments for the cluster nodes"
     default     = []
@@ -249,6 +255,12 @@ variable "jump_host" {
     default     = ""
 }
 
+variable "private_network_mtu" {
+  type        = number
+  description = "MTU value for the private network interface on RHEL and RHCOS nodes"
+  default     = 1450
+}
+
 variable "installer_log_level" {
     description = "Set the log level required for openshift-install commands"
     default = "info"
@@ -263,7 +275,7 @@ variable "helpernode_repo" {
 variable "helpernode_tag" {
     description = "Set the branch/tag name or commit# for using ocp4-helpernode repo"
     # Checkout level for https://github.com/RedHatOfficial/ocp4-helpernode which is used for setting up services required on bastion node
-    default = "1ac7f276b537cd734240eda9ed554a254ba80629"
+    default = "324e09e3d303101874f540730c993cd986ddbc04"
 }
 
 variable "install_playbook_repo" {
@@ -275,7 +287,12 @@ variable "install_playbook_repo" {
 variable "install_playbook_tag" {
     description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
     # Checkout level for https://github.com/ocp-power-automation/ocp4-playbooks which is used for running ocp4 installations steps
-    default = "10fec74c9e987b39f7af1127abe304a9e41f8e65"
+    default = "284b597b3e88c635e3069b82926aa16812238492"
+}
+
+variable "helm_repo" {
+    description = "Set the URL after http_server_repo_main_dir pointing to the Python helm modules"
+    default = "https://get.helm.sh/helm-v3.6.3-linux-ppc64le.tar.gz"
 }
 
 variable "ansible_extra_options" {
@@ -329,8 +346,24 @@ variable "cluster_id" {
     default   = ""
 }
 
+variable "fips_compliant" {
+  type        = bool
+  description = "Set to true to enable usage of FIPS for OCP deployment."
+  default     = false
+}
+
 variable "dns_forwarders" {
     default   = "8.8.8.8; 8.8.4.4"
+}
+
+variable "lb_ipaddr" {
+    description = "Define the preconfigured external Load Balancer"
+    default = ""    
+}
+
+variable "ext_dns" {
+    description = "Define the preconfigured external DNS and Load Balancer"
+    default = ""
 }
 
 variable "mount_etcd_ramdisk" {
@@ -399,6 +432,21 @@ variable "upgrade_delay_time" {
 variable "cni_network_provider" {
     description = "Set the default Container Network Interface (CNI) network provider"
     default = "OpenshiftSDN"
+}
+
+variable "cluster_network_cidr" {
+    description = "blocks of IP addresses from which pod IP addresses are allocated."
+    default = "10.128.0.0/14"
+}
+
+variable "cluster_network_hostprefix" {
+    description = "The subnet prefix length to assign to each individual node."
+    default = "23"
+}
+
+variable "service_network" {
+    description = "blocks of IP addresses from which service addresses are allocated."
+    default = "172.30.0.0/16"
 }
 
 ################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -29,5 +29,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }


### PR DESCRIPTION
Fixes #220

Implementation how I did it at another customer. I have tested it again on our local test env and both (git and curl) was working like it should be.

I also added a helm_repo URL to the var.tfvars (as long the package is still needed), so that users can also host this package on their own environment.