### PR TITLE
network_custom

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -271,4 +271,7 @@ This variable is used to set the default Container Network Interface (CNI) netwo
 
 ```
 cni_network_provider       = "OpenshiftSDN"
+cluster_network_cidr        = "10.128.0.0/14"
+cluster_network_hostprefix  = "23"
+service_network             = "172.30.0.0/16"
 ```

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -40,29 +40,32 @@ locals {
     local_registry_ocp_image = "registry.${var.cluster_id}.${local.cluster_domain}:5000/${local.ocp_release_repo}:${var.ocp_release_tag}"
 
     install_vars = {
-        bastion_vip              = var.bastion_vip
-        cluster_id               = var.cluster_id
-        cluster_domain           = local.cluster_domain
-        pull_secret              = var.pull_secret
-        public_ssh_key           = var.public_key
-        storage_type             = var.storage_type
-        log_level                = var.log_level
-        release_image_override   = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
-        enable_local_registry    = var.enable_local_registry
-        node_connection_timeout  = 60 * var.connection_timeout
-        rhcos_pre_kernel_options = var.rhcos_pre_kernel_options
-        rhcos_kernel_options     = var.rhcos_kernel_options
-        sysctl_tuned_options     = var.sysctl_tuned_options
-        sysctl_options           = var.sysctl_options
-        match_array              = indent(2,var.match_array)
-        setup_squid_proxy        = var.setup_squid_proxy
-        squid_source_range       = var.cidr
-        proxy_url                = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
-        no_proxy                 = var.cidr
-        chrony_config            = var.chrony_config
-        chrony_config_servers    = var.chrony_config_servers
-        chrony_allow_range       = var.cidr
-        cni_network_provider     = var.cni_network_provider
+        bastion_vip                = var.bastion_vip
+        cluster_id                 = var.cluster_id
+        cluster_domain             = local.cluster_domain
+        pull_secret                = var.pull_secret
+        public_ssh_key             = var.public_key
+        storage_type               = var.storage_type
+        log_level                  = var.log_level
+        release_image_override     = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
+        enable_local_registry      = var.enable_local_registry
+        node_connection_timeout    = 60 * var.connection_timeout
+        rhcos_pre_kernel_options   = var.rhcos_pre_kernel_options
+        rhcos_kernel_options       = var.rhcos_kernel_options
+        sysctl_tuned_options       = var.sysctl_tuned_options
+        sysctl_options             = var.sysctl_options
+        match_array                = indent(2,var.match_array)
+        setup_squid_proxy          = var.setup_squid_proxy
+        squid_source_range         = var.cidr
+        proxy_url                  = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
+        no_proxy                   = var.cidr
+        chrony_config              = var.chrony_config
+        chrony_config_servers      = var.chrony_config_servers
+        chrony_allow_range         = var.cidr
+        cni_network_provider       = var.cni_network_provider
+        cluster_network_cidr       = var.cluster_network_cidr
+        cluster_network_hostprefix = var.cluster_network_hostprefix
+        service_network            = var.service_network
     }
 
     upgrade_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -56,3 +56,7 @@ bastion_vip: "${bastion_vip}"
 %{ endif ~}
 
 cni_network_provider: "${cni_network_provider}"
+
+cluster_network_cidr: "${cluster_network_cidr}"
+cluster_network_hostprefix: "${cluster_network_hostprefix}"
+service_network: "${service_network}"

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -73,3 +73,6 @@ variable "upgrade_pause_time" {}
 variable "upgrade_delay_time" {}
 
 variable "cni_network_provider" {}
+variable "cluster_network_cidr" {}
+variable "cluster_network_hostprefix" {}
+variable "service_network" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -183,4 +183,7 @@ module "install" {
     chrony_config                   = var.chrony_config
     chrony_config_servers           = var.chrony_config_servers
     cni_network_provider            = var.cni_network_provider
+    cluster_network_cidr            = var.cluster_network_cidr
+    cluster_network_hostprefix      = var.cluster_network_hostprefix
+    service_network                 = var.service_network
 }

--- a/var.tfvars
+++ b/var.tfvars
@@ -91,3 +91,6 @@ cluster_id                  = ""         # It will use random generated id with 
 #upgrade_delay_time         = "600"
 
 #cni_network_provider       = "OpenshiftSDN"
+#cluster_network_cidr        = "10.128.0.0/14"
+#cluster_network_hostprefix  = "23"
+#service_network             = "172.30.0.0/16"

--- a/variables.tf
+++ b/variables.tf
@@ -281,7 +281,7 @@ variable "install_playbook_repo" {
 variable "install_playbook_tag" {
     description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
     # Checkout level for https://github.com/ocp-power-automation/ocp4-playbooks which is used for running ocp4 installations steps
-    default = "7c5c0158fb96df7816b79da2274ff21b2fd61c1c"
+    default = "86e8f06fa3e008fbdd6188659cb45a3cbe716e26"
 }
 
 variable "ansible_extra_options" {
@@ -415,6 +415,21 @@ variable "upgrade_delay_time" {
 variable "cni_network_provider" {
     description = "Set the default Container Network Interface (CNI) network provider"
     default = "OpenshiftSDN"
+}
+
+variable "cluster_network_cidr" {
+    description = "blocks of IP addresses from which pod IP addresses are allocated."
+    default = "10.128.0.0/14"
+}
+
+variable "cluster_network_hostprefix" {
+    description = "The subnet prefix length to assign to each individual node."
+    default = "23"
+}
+
+variable "service_network" {
+    description = "blocks of IP addresses from which service addresses are allocated."
+    default = "172.30.0.0/16"
 }
 
 ################################################################


### PR DESCRIPTION
Add the possibility to choose the clusterNetwork and serviceNetwork CIDR. (mandatory for multicluster implementation with RHACM and submariner).

This change depends from another PR : https://github.com/ocp-power-automation/ocp4-playbooks/pull/130

/assign @bpradipt