### PR TITLE
Upgrade to Terraform 1.0.11

### DIFF
--- a/modules/1_bastion/versions.tf
+++ b/modules/1_bastion/versions.tf
@@ -33,5 +33,4 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
 }

--- a/modules/2_network/versions.tf
+++ b/modules/2_network/versions.tf
@@ -25,5 +25,4 @@ terraform {
       version = "~> 1.32"
     }
   }
-  required_version = "~> 0.13.0"
 }

--- a/modules/3_helpernode/versions.tf
+++ b/modules/3_helpernode/versions.tf
@@ -25,5 +25,4 @@ terraform {
       version = "~> 2.1"
     }
   }
-  required_version = "~> 0.13.0"
 }

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -33,5 +33,4 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
 }

--- a/modules/5_install/versions.tf
+++ b/modules/5_install/versions.tf
@@ -25,5 +25,4 @@ terraform {
       version = "~> 2.1"
     }
   }
-  required_version = "~> 0.13.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -29,5 +29,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 1.0.11"
+  required_version = ">= 1.0.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -29,5 +29,5 @@ terraform {
       version = "~> 2.3"
     }
   }
-  required_version = "~> 0.13.0"
+  required_version = "~> 1.0.11"
 }


### PR DESCRIPTION
Removes the terraform required_version variable from all modules. I went with this version because it was available on brew when I did a fresh install on my Mac.

[Install instructions](https://learn.hashicorp.com/tutorials/terraform/install-cli)


[Upgrade instructions](https://www.terraform.io/upgrade-guides/1-0.html)