### PR TITLE
force centos stream to use ansible 2.9 like rhel8

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -270,7 +270,7 @@ resource "null_resource" "bastion_packages" {
     }
     provisioner "remote-exec" {
         inline = [
-           "sudo yum install -y ansible"
+           "sudo yum install -y ansible-2.9.*"
         ]
     }
     provisioner "remote-exec" {


### PR DESCRIPTION
since centos stream, the ansible version installed with `yum install ansible` is ansible-core 2.12.
This produce error when executing helpernode playbooks.

Using `ansible.noarch` force to use ansible 2.9 (like rhel8)

This is compatible with rhel8  