### PR TITLE
bastion fqdn with clusterID as subdmain

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -103,8 +103,8 @@ resource "null_resource" "bastion_init" {
         inline = [
             "sudo chmod 600 $HOME/.ssh/id_rsa*",
             "sudo sed -i.bak -e 's/^ - set_hostname/# - set_hostname/' -e 's/^ - update_hostname/# - update_hostname/' /etc/cloud/cloud.cfg",
-            "sudo hostnamectl set-hostname --static ${lower(var.cluster_id)}-bastion-${count.index}.${var.cluster_domain}",
-            "echo 'HOSTNAME=${lower(var.cluster_id)}-bastion-${count.index}.${var.cluster_domain}' | sudo tee -a /etc/sysconfig/network > /dev/null",
+            "sudo hostnamectl set-hostname --static ${lower(var.cluster_id)}-bastion-${count.index}.${lower(var.cluster_id)}.${var.cluster_domain}",
+            "echo 'HOSTNAME=${lower(var.cluster_id)}-bastion-${count.index}.${lower(var.cluster_id)}.${var.cluster_domain}' | sudo tee -a /etc/sysconfig/network > /dev/null",
             "sudo hostname -F /etc/hostname",
             "echo 'vm.max_map_count = 262144' | sudo tee --append /etc/sysctl.conf > /dev/null",
         ]


### PR DESCRIPTION
I notice that my bastion doesn't have the fqdn I was expected.

If my domain is `example.com` and my clusterID is `ocp4` the bastion fqdn is :  

`ocp4-bastion-0.example.com`
while I expect it to be :  
`ocp4-bastion-0.ocp4.example.com`

