### PR TITLE
Install latest ansible with required modules.

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -270,7 +270,10 @@ resource "null_resource" "bastion_packages" {
     }
     provisioner "remote-exec" {
         inline = [
-           "sudo yum install -y ansible-2.9.*"
+            "sudo yum install -y ansible",
+            "ansible-galaxy collection install community.crypto",
+            "ansible-galaxy collection install ansible.posix",
+            "ansible-galaxy collection install kubernetes.core"       
         ]
     }
     provisioner "remote-exec" {


### PR DESCRIPTION
The latest CentOS stream could not install  ansible2.9.* which include all modules we need, now it just install latest ansible with core only, we need to install other modules manually. For RHEL, the ansible 2.9 will be installed.

Signed-off-by: CS Zhang <zhangcho@us.ibm.com>