### PR TITLE
Update default CNI to OVNKubernetes

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -305,7 +305,7 @@ eus_upstream               = "" (e.g. `"https://ppc64le.ocp.releases.ci.openshif
 This variable is used to set the default Container Network Interface (CNI) network provider such as OpenShiftSDN or OVNKubernetes
 
 ```
-cni_network_provider       = "OpenshiftSDN"
+cni_network_provider       = "OVNKubernetes"
 cluster_network_cidr        = "10.128.0.0/14"
 cluster_network_hostprefix  = "23"
 service_network             = "172.30.0.0/16"

--- a/var.tfvars
+++ b/var.tfvars
@@ -95,7 +95,7 @@ cluster_id        = ""         # It will use random generated id with cluster_id
 #eus_upgrade_image          = ""  #(quay.io/openshift-release-dev/ocp-release@sha256:xyz..)
 #eus_upstream               = ""  #https://ppc64le.ocp.releases.ci.openshift.org/graph
 
-#cni_network_provider       = "OpenshiftSDN"
+#cni_network_provider       = "OVNKubernetes"
 #cluster_network_cidr        = "10.128.0.0/14"
 #cluster_network_hostprefix  = "23"
 #service_network             = "172.30.0.0/16"

--- a/variables.tf
+++ b/variables.tf
@@ -446,7 +446,7 @@ variable "eus_upstream" {
 
 variable "cni_network_provider" {
   description = "Set the default Container Network Interface (CNI) network provider"
-  default     = "OpenshiftSDN"
+  default     = "OVNKubernetes"
 }
 
 variable "cluster_network_cidr" {


### PR DESCRIPTION
With OCP 4.12, the default network type is OVNKubernetes
Reference: https://github.com/openshift/installer/pull/6014

Signed-off-by: Pravin D'silva <pravin.dsilva@ibm.com>
