### PR TITLE
Add support for LUKS encryption for OCP4

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -300,3 +300,18 @@ cluster_network_cidr        = "10.128.0.0/14"
 cluster_network_hostprefix  = "23"
 service_network             = "172.30.0.0/16"
 ```
+
+These set of variables are specific for LUKS encryption configuration and installation.
+
+```
+luks_compliant               = false # Set it true if you prefer to use FIPS enable in ocp deployment
+luks_config                  = [ { thumbprint = "", url = "" }, { thumbprint = "", url = "" }, { thumbprint = "", url = "" } ]
+luks_filesystem_device       = "/dev/mapper/root"  #Set this value for file system device
+luks_format                  = "xfs"  #Set value of format for filesystem 
+luks_wipe_filesystem         = true  #Configures the FileSystem to be wiped 
+luks_device                  = "/dev/disk/by-partlabel/root"  #Set value of luks device 
+luks_label                   = "luks-root"  #Set value of tang label 
+luks_options                 = ["--cipher", "aes-cbc-essiv:sha256"]  #Set List of luks options for the luks encryption 
+luks_wipe_volume             = true  #Configures the luks encrypted partition to be wiped 
+luks_name                    = "root"  #Set value of luks name 
+```

--- a/modules/5_install/5_1_installconfig/installconfig.tf
+++ b/modules/5_install/5_1_installconfig/installconfig.tf
@@ -72,7 +72,17 @@ locals {
     service_network            = var.service_network
     # Set CNI network MTU to MTU - 100 for OVNKubernetes and MTU - 50 for OpenShiftSDN(default).
     # Add new conditions here when we have more network providers
-    cni_network_mtu = var.cni_network_provider == "OVNKubernetes" ? var.private_network_mtu - 100 : var.private_network_mtu - 50
+    cni_network_mtu        = var.cni_network_provider == "OVNKubernetes" ? var.private_network_mtu - 100 : var.private_network_mtu - 50
+    luks_compliant         = var.luks_compliant
+    luks_config            = var.luks_config
+    luks_filesystem_device = var.luks_filesystem_device
+    luks_format            = var.luks_format
+    luks_wipe_filesystem   = var.luks_wipe_filesystem
+    luks_device            = var.luks_device
+    luks_label             = var.luks_label
+    luks_options           = var.luks_options
+    luks_wipe_volume       = var.luks_wipe_volume
+    luks_name              = var.luks_name
   }
 
   upgrade_vars = {

--- a/modules/5_install/5_1_installconfig/templates/install_vars.yaml
+++ b/modules/5_install/5_1_installconfig/templates/install_vars.yaml
@@ -62,3 +62,26 @@ cluster_network_cidr: "${cluster_network_cidr}"
 cluster_network_hostprefix: "${cluster_network_hostprefix}"
 service_network: "${service_network}"
 cni_network_mtu: "${cni_network_mtu}"
+
+%{ if luks_compliant && length(luks_config) > 0 ~}
+luks:
+ enabled: true
+ config:
+%{ for item in luks_config ~}
+    - thumbprint: ${item.thumbprint}
+      url: ${item.url}
+%{ endfor ~}
+ filesystem_device: ${luks_filesystem_device}
+ format: ${luks_format}
+ wipeFileSystem: "${luks_wipe_filesystem}"
+ device: ${luks_device}
+ label: ${luks_label}
+%{ if length(luks_options) > 0 ~}
+ options:
+%{ for item in luks_options ~}
+    - ${item}
+%{ endfor ~}
+%{ endif ~}
+ wipeVolume: "${luks_wipe_volume}"
+ name: ${luks_name}
+%{ endif ~}

--- a/modules/5_install/5_1_installconfig/variables.tf
+++ b/modules/5_install/5_1_installconfig/variables.tf
@@ -80,3 +80,14 @@ variable "cni_network_provider" {}
 variable "cluster_network_cidr" {}
 variable "cluster_network_hostprefix" {}
 variable "service_network" {}
+
+variable "luks_compliant" { default = false }
+variable "luks_config" {}
+variable "luks_filesystem_device" {}
+variable "luks_format" {}
+variable "luks_wipe_filesystem" {}
+variable "luks_device" {}
+variable "luks_label" {}
+variable "luks_options" {}
+variable "luks_wipe_volume" {}
+variable "luks_name" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -168,6 +168,16 @@ module "installconfig" {
   cluster_network_cidr       = var.cluster_network_cidr
   cluster_network_hostprefix = var.cluster_network_hostprefix
   service_network            = var.service_network
+  luks_compliant             = var.luks_compliant
+  luks_config                = var.luks_config
+  luks_filesystem_device     = var.luks_filesystem_device
+  luks_format                = var.luks_format
+  luks_wipe_filesystem       = var.luks_wipe_filesystem
+  luks_device                = var.luks_device
+  luks_label                 = var.luks_label
+  luks_options               = var.luks_options
+  luks_wipe_volume           = var.luks_wipe_volume
+  luks_name                  = var.luks_name
 }
 
 module "bootstrapnode" {

--- a/var.tfvars
+++ b/var.tfvars
@@ -95,3 +95,14 @@ cluster_id        = ""         # It will use random generated id with cluster_id
 #cluster_network_hostprefix  = "23"
 #service_network             = "172.30.0.0/16"
 #private_network_mtu         = "1450"
+
+#luks_compliant              = false # Set it true if you prefer to use LUKS enable in OCP deployment
+#luks_config                 = [ { thumbprint = "", url = "" } ]
+#luks_filesystem_device      = "/dev/mapper/root"  #Set the Path of device to be luks encrypted
+#luks_format                 = "xfs"  #Set the Format of the FileSystem to be luks encrypted
+#luks_wipe_filesystem         = true  #Configures the FileSystem to be wiped
+#luks_device                 = "/dev/disk/by-partlabel/root"  #Set the Path of luks encrypted partition
+#luks_label                  = "luks-root"  #Set the value for user label of luks encrypted partition
+#luks_options                = ["--cipher", "aes-cbc-essiv:sha256"]  #Set List of luks options for the luks encryption
+#luks_wipe_volume             = true  #Configures the luks encrypted partition to be wiped
+#luks_name                   = "root" #Set the value for the user label of Filesystem to be luks encrypted

--- a/variables.tf
+++ b/variables.tf
@@ -462,3 +462,71 @@ variable "ocp_release_tag" {
   description = "The version of OpenShift you want to sync."
   default     = "4.4.9-ppc64le"
 }
+
+
+################################################################
+# LUKS variables
+################################################################
+
+variable "luks_compliant" {
+  type        = bool
+  description = "Set to true to enable usage of LUKS for OCP deployment."
+  default     = false
+}
+
+variable "luks_config" {
+  type = list(object({
+    thumbprint = string,
+    url        = string
+  }))
+  description = "List of tang servers and thumbprint to apply"
+  default     = []
+}
+
+variable "luks_filesystem_device" {
+  type        = string
+  description = "Path of device to be luks encrypted"
+  default     = "/dev/mapper/root"
+}
+
+variable "luks_format" {
+  type        = string
+  description = "Format of the FileSystem to be luks encrypted"
+  default     = "xfs"
+}
+
+variable "luks_wipe_filesystem" {
+  type        = bool
+  description = "Configures the FileSystem to be wiped"
+  default     = true
+}
+
+variable "luks_device" {
+  type        = string
+  description = "Path of luks encrypted partition"
+  default     = "/dev/disk/by-partlabel/root"
+}
+
+variable "luks_label" {
+  type        = string
+  description = "User label of luks encrypted partition"
+  default     = "luks-root"
+}
+
+variable "luks_options" {
+  type        = list(string)
+  description = "List of luks options for the luks encryption"
+  default     = ["--cipher", "aes-cbc-essiv:sha256"]
+}
+
+variable "luks_wipe_volume" {
+  type        = bool
+  description = "Configures the luks encrypted partition to be wiped"
+  default     = true
+}
+
+variable "luks_name" {
+  type        = string
+  description = "User label of Filesystem to be luks encrypted"
+  default     = "root"
+}


### PR DESCRIPTION
This feature enables LUKS encryption variables and updates the install modules to setup LUKS variables. The MachineConfig is automatically used as part of the ocp4-playbooks when LUKS is enabled.

The e2e tests we have completed are - apply, verify luks status, destroy with and without luks enabled.

Please find attached a sample result from the execution:

### 1.luks-enabled


a. apply

```
[root@stocked1 ocp4-upi-powervmp9]# terraform output
bastion_ip = "*.*.*.*"
bastion_ssh_command = "ssh root@*.*.*.*"
bootstrap_ip = "*.*.*.*"
cluster_id = "ocp-1711-68be"
etc_hosts_entries = <<EOT

*.*.*.* api.ocp-1711-68be.ibm.com console-openshift-console.apps.ocp-1711-68be.ibm.com integrated-oauth-server-openshift-authentication.apps.ocp-1711-68be.ibm.com oauth-openshift.apps.ocp-1711-68be.ibm.com prometheus-k8s-openshift-monitoring.apps.ocp-1711-68be.ibm.com grafana-openshift-monitoring.apps.ocp-1711-68be.ibm.com example.apps.ocp-1711-68be.ibm.com

EOT
install_status = "COMPLETED"
master_ips = [
  "*.*.*.*",
  "*.*.*.*",
  "*.*.*.*",
]
oc_server_url = "https://api.ocp-1711-68be.ibm.com:6443"
storageclass_name = "nfs-storage-provisioner"
web_console_url = "https://console-openshift-console.apps.ocp-1711-68be.ibm.com"
worker_ips = [
  "*.*.*.*",
  "*.*.*.*",
]
```


b.verify

```
Last login: Mon Nov 21 06:59:52 2022 from *.*.*.*
[core@master-1 ~]$ sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdc4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
[core@master-1 ~]$ sudo clevis luks list -d  /dev/sdc4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'
[core@master-0 ~]$ sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdd4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
[core@master-0 ~]$ sudo clevis luks list -d  /dev/sdc4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'
[core@master-0 ~]$ sudo clevis luks list -d  /dev/sdd4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'

[core@master-2 ~]$ sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdd4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
[core@master-2 ~]$ sudo clevis luks list -d  /dev/sdd4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'


Workers:
[core@worker-1 ~]$ sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdb4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
[core@worker-1 ~]$ sudo clevis luks list -d  /dev/sdb4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'

[core@worker-0 ~]$ sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdb4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
[core@worker-0 ~]$ sudo clevis luks list -d  /dev/sdb4
1: sss '{"t":1,"pins":{"tang":[{"url":"http://*.*.*.*:*"}]}}'

```


c. destroy completed successfully


### 2.luks-disabled

a. apply

Apply complete! Resources: 4 added, 0 changed, 1 destroyed.

Outputs:

```
bastion_private_ip = "*.*.*.*"
bastion_public_ip = "*.*.*.*"
bastion_ssh_command = "ssh -i data/id_rsa root@*.*.*.*"
bootstrap_ip = "*.*.*.*"
cluster_authentication_details = "Cluster authentication details are available in *.*.*.* under ~/openstack-upi/auth"
cluster_id = "luks-1611-bcba"
dns_entries = <<EOT

api.****.com.  IN  A  *.*.*.*
*.****.ibm.com.  IN  A  *.*.*.*

EOT
etc_hosts_entries = <<EOT

*.*.*.* api.****.com console-openshift-console.****.ibm.com integrated-oauth-server-openshift-authentication.****.ibm.com oauth-openshift.****.ibm.com prometheus-k8s-openshift-monitoring.****.ibm.com grafana-openshift-monitoring.****.ibm.com example.****.ibm.com

EOT
install_status = "COMPLETED"
master_ips = [
  "*.*.*.*",
  "*.*.*.*",
  "*.*.*.*",
]
name_prefix = "luks-1611-bcba-syd05-"
oc_server_url = "https://api.****.com:6443"
storageclass_name = "nfs-storage-provisioner"
web_console_url = "https://console-openshift-console.****.ibm.com"
worker_ips = [
  "*.*.*.*",
  "*.*.*.*",
]
```
b. verify

Masters:

```
[core@syd05-master-0 ~]$ sudo cryptsetup status root
/dev/mapper/root is inactive.
[core@syd05-master-1 ~]$ sudo cryptsetup status root
/dev/mapper/root is inactive.
[core@syd05-master-2 ~]$ sudo cryptsetup status root
/dev/mapper/root is inactive.
```

Workers:

```
[core@syd05-worker-0 ~]$ sudo cryptsetup status root
/dev/mapper/root is inactive.
[core@syd05-worker-1 ~]$ sudo cryptsetup status root
/dev/mapper/root is inactive.
```
c. destroy completed successfully

**Note, we discussed updating install_playbook_tag to a new default for testing. I have left this the same as the origin. Please let me know if you want me to update the tag.**


Signed-off-by: Gaurav Bankar <Gaurav.Bankar@ibm.com>