### PR TITLE
Use UUID in fstab for nfs export FS for stability after reboot.

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -332,11 +332,12 @@ resource "null_resource" "setup_nfs_disk" {
     inline = [
       "sudo rm -rf mkdir ${local.storage_path}; sudo mkdir -p ${local.storage_path}; sudo chmod -R 755 ${local.storage_path}",
       "sudo chmod +x /tmp/create_disk_link.sh",
-      # Fix for copying file from Windows OS having CR
+      # Fix for copying file from Windows OS having CR,
       "sudo sed -i 's/\r//g' /tmp/create_disk_link.sh",
       "sudo /tmp/create_disk_link.sh",
       "sudo mkfs.xfs /dev/${local.disk_config.disk_name}",
-      "echo '/dev/${local.disk_config.disk_name} ${local.storage_path} xfs defaults 0 0' | sudo tee -a /etc/fstab > /dev/null",
+      "MY_DEV_UUID=$(sudo blkid -o export /dev/${local.disk_config.disk_name} | awk '/UUID/{ print }')",
+      "echo \"$MY_DEV_UUID ${local.storage_path} xfs defaults 0 0\" | sudo tee -a /etc/fstab > /dev/null",
       "sudo mount ${local.storage_path}",
     ]
   }


### PR DESCRIPTION
link `/dev/disk/pv-storage-disk` points to a `/dev/dm-*` when using multipathed disk.
This dm- device can be renumbered after a reboot, which could prevent the bastion/helpernode to reboot properly (maintenance mode because /export cannot be mount).

The best way is to get the UUID generated after the creation of the FS and use this one in the fstab.