### PR TITLE
trigger helpernode when number of master changed

### DIFF
--- a/modules/3_helpernode/helpernode.tf
+++ b/modules/3_helpernode/helpernode.tf
@@ -83,6 +83,7 @@ resource "null_resource" "config" {
   triggers = {
     bootstrap_count = var.bootstrap_port_ip == "" ? 0 : 1
     worker_count    = length(var.worker_port_ips)
+    master_count    = length(var.master_port_ips)
   }
 
   connection {


### PR DESCRIPTION
Add master_count in helpernode module triggers.

This allow users to add/replace a master node.