### PR TITLE
WIP: Configure fips on the bastion node of openshift cluster

### DIFF
--- a/modules/1_bastion/variables.tf
+++ b/modules/1_bastion/variables.tf
@@ -51,3 +51,4 @@ variable "volume_storage_template" {}
 
 variable "setup_squid_proxy" {}
 variable "proxy" {}
+variable "fips_compliant" {}

--- a/modules/1_bastion/versions.tf
+++ b/modules/1_bastion/versions.tf
@@ -32,6 +32,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.4"
     }
+    time = {
+      source = "hashicorp/time"
+      version = "0.9.1"
   }
   required_version = ">= 1.2.0"
 }

--- a/ocp.tf
+++ b/ocp.tf
@@ -66,6 +66,7 @@ module "bastion" {
   volume_storage_template         = var.volume_storage_template
   setup_squid_proxy               = var.setup_squid_proxy
   proxy                           = var.proxy
+  fips_compliant                  = var.fips_compliant
 }
 
 module "network" {
@@ -83,6 +84,7 @@ module "network" {
 }
 
 module "helpernode" {
+  depends_on = [module.bastion]
   source = "./modules/3_helpernode"
 
   cluster_domain            = var.cluster_domain


### PR DESCRIPTION
To configure the bastion node of openshfit cluster with FIPS enablement on PowerVM.

- As a part of fips enablement we have already enabled fips on master nodes and worker nodes, In this PR we are going to enable fips on the bastion node.