### PR TITLE
Added Public Subnet variable to Bastion for Disconnected cluster support

### DIFF
--- a/modules/1_bastion/outputs.tf
+++ b/modules/1_bastion/outputs.tf
@@ -20,5 +20,11 @@
 
 output "bastion_ip" {
   depends_on = [null_resource.bastion_packages, null_resource.setup_nfs_disk]
-  value      = openstack_compute_instance_v2.bastion.*.access_ip_v4
+  value      = var.pub_network_name == "" ? openstack_compute_instance_v2.bastion.*.access_ip_v4 : [openstack_compute_instance_v2.bastion[0].network[1].fixed_ip_v4]
+}
+
+
+output "pub_bastion_ip" {
+  depends_on = [null_resource.bastion_packages, null_resource.setup_nfs_disk]
+  value      = var.pub_network_name == "" ? "" : openstack_compute_instance_v2.bastion[0].access_ip_v4
 }

--- a/modules/1_bastion/variables.tf
+++ b/modules/1_bastion/variables.tf
@@ -26,6 +26,7 @@ variable "cluster_id" {
 }
 variable "bastion" {}
 variable "bastion_port_ids" {}
+variable "pub_network_name" {}
 
 variable "scg_id" {}
 variable "openstack_availability_zone" {}

--- a/modules/3_helpernode/helpernode.tf
+++ b/modules/3_helpernode/helpernode.tf
@@ -89,7 +89,7 @@ resource "null_resource" "config" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"

--- a/modules/3_helpernode/variables.tf
+++ b/modules/3_helpernode/variables.tf
@@ -37,6 +37,7 @@ variable "allocation_pools" {}
 
 variable "bastion_vip" {}
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}
 variable "ssh_agent" {}

--- a/modules/4_nodes/4_3_workernodes/variables.tf
+++ b/modules/4_nodes/4_3_workernodes/variables.tf
@@ -19,6 +19,7 @@
 ################################################################
 
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "cluster_id" {}
 
 variable "worker" {

--- a/modules/4_nodes/4_3_workernodes/workernodes.tf
+++ b/modules/4_nodes/4_3_workernodes/workernodes.tf
@@ -104,7 +104,7 @@ resource "null_resource" "remove_worker" {
   count      = var.worker["count"]
   depends_on = [openstack_compute_instance_v2.worker]
   triggers = {
-    bastion_ip         = var.bastion_ip
+    bastion_ip         = var.pub_bastion_ip == "" ? var.bastion_ip : var.pub_bastion_ip
     rhel_username      = var.rhel_username
     private_key        = var.private_key
     ssh_agent          = var.ssh_agent

--- a/modules/5_install/5_1_installconfig/installconfig.tf
+++ b/modules/5_install/5_1_installconfig/installconfig.tf
@@ -111,7 +111,7 @@ resource "null_resource" "pre_install" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[count.index]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[count.index] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"
@@ -141,7 +141,7 @@ resource "null_resource" "install_config" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"

--- a/modules/5_install/5_1_installconfig/variables.tf
+++ b/modules/5_install/5_1_installconfig/variables.tf
@@ -29,6 +29,7 @@ variable "cidr" {}
 
 variable "bastion_vip" {}
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}
 variable "ssh_agent" {}

--- a/modules/5_install/5_2_bootstrapconfig/bootstrapconfig.tf
+++ b/modules/5_install/5_2_bootstrapconfig/bootstrapconfig.tf
@@ -23,7 +23,7 @@ resource "null_resource" "bootstrap_config" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"

--- a/modules/5_install/5_2_bootstrapconfig/variables.tf
+++ b/modules/5_install/5_2_bootstrapconfig/variables.tf
@@ -20,6 +20,7 @@
 
 
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}
 variable "ssh_agent" {}

--- a/modules/5_install/5_3_bootstrapcomplete/bootstrapcomplete.tf
+++ b/modules/5_install/5_3_bootstrapcomplete/bootstrapcomplete.tf
@@ -23,7 +23,7 @@ resource "null_resource" "bootstrap_complete" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"

--- a/modules/5_install/5_3_bootstrapcomplete/variables.tf
+++ b/modules/5_install/5_3_bootstrapcomplete/variables.tf
@@ -20,6 +20,7 @@
 
 
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}
 variable "ssh_agent" {}

--- a/modules/5_install/5_4_installcomplete/install.tf
+++ b/modules/5_install/5_4_installcomplete/install.tf
@@ -45,7 +45,7 @@ resource "null_resource" "install" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"
@@ -67,7 +67,7 @@ resource "null_resource" "upgrade" {
   connection {
     type         = "ssh"
     user         = var.rhel_username
-    host         = var.bastion_ip[0]
+    host         = var.pub_bastion_ip == "" ? var.bastion_ip[0] : var.pub_bastion_ip
     private_key  = var.private_key
     agent        = var.ssh_agent
     timeout      = "${var.connection_timeout}m"

--- a/modules/5_install/5_4_installcomplete/variables.tf
+++ b/modules/5_install/5_4_installcomplete/variables.tf
@@ -27,6 +27,7 @@ variable "cluster_id" {
 
 variable "bastion_vip" {}
 variable "bastion_ip" {}
+variable "pub_bastion_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}
 variable "ssh_agent" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -46,6 +46,7 @@ module "bastion" {
   cluster_id                      = local.cluster_id
   bastion                         = var.bastion
   bastion_port_ids                = module.network.bastion_port_ids
+  pub_network_name                = var.pub_network_name
   scg_id                          = var.scg_id
   openstack_availability_zone     = var.openstack_availability_zone
   rhel_username                   = var.rhel_username
@@ -95,6 +96,7 @@ module "helpernode" {
   allocation_pools          = module.network.allocation_pools
   bastion_vip               = module.network.bastion_vip
   bastion_ip                = module.bastion.bastion_ip
+  pub_bastion_ip            = module.bastion.pub_bastion_ip
   rhel_username             = var.rhel_username
   private_key               = local.private_key
   ssh_agent                 = var.ssh_agent
@@ -129,6 +131,7 @@ module "installconfig" {
   bastion                    = var.bastion
   bastion_vip                = module.network.bastion_vip
   bastion_ip                 = module.bastion.bastion_ip
+  pub_bastion_ip             = module.bastion.pub_bastion_ip
   rhel_username              = var.rhel_username
   private_key                = local.private_key
   ssh_agent                  = var.ssh_agent
@@ -208,6 +211,7 @@ module "bootstrapconfig" {
   source     = "./modules/5_install/5_2_bootstrapconfig"
 
   bastion_ip            = module.bastion.bastion_ip
+  pub_bastion_ip        = module.bastion.pub_bastion_ip
   rhel_username         = var.rhel_username
   private_key           = local.private_key
   ssh_agent             = var.ssh_agent
@@ -235,6 +239,7 @@ module "bootstrapcomplete" {
   source     = "./modules/5_install/5_3_bootstrapcomplete"
 
   bastion_ip            = module.bastion.bastion_ip
+  pub_bastion_ip        = module.bastion.pub_bastion_ip
   rhel_username         = var.rhel_username
   private_key           = local.private_key
   ssh_agent             = var.ssh_agent
@@ -247,6 +252,7 @@ module "workernodes" {
   source = "./modules/4_nodes/4_3_workernodes"
 
   bastion_ip                  = module.network.bastion_vip == "" ? module.bastion.bastion_ip[0] : module.network.bastion_vip
+  pub_bastion_ip              = module.bastion.pub_bastion_ip
   cluster_id                  = local.cluster_id
   worker                      = var.worker
   scg_id                      = var.scg_id
@@ -268,6 +274,7 @@ module "install" {
   cluster_id            = local.cluster_id
   bastion_vip           = module.network.bastion_vip
   bastion_ip            = module.bastion.bastion_ip
+  pub_bastion_ip        = module.bastion.pub_bastion_ip
   rhel_username         = var.rhel_username
   private_key           = local.private_key
   ssh_agent             = var.ssh_agent

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 }
 
 output "bastion_ip" {
-  value = join(", ", module.bastion.bastion_ip)
+  value = var.pub_network_name == "" ? join(", ", module.bastion.bastion_ip) : module.bastion.pub_bastion_ip
 }
 
 output "bastion_vip" {
@@ -31,7 +31,7 @@ output "bastion_vip" {
 }
 
 output "bastion_ssh_command" {
-  value = "ssh -i ${var.private_key_file} ${var.rhel_username}@${module.network.bastion_vip == "" ? module.bastion.bastion_ip[0] : module.network.bastion_vip}"
+  value = "ssh -i ${var.private_key_file} ${var.rhel_username}@${module.network.bastion_vip == "" ? (var.pub_network_name == "" ? module.bastion.bastion_ip[0] : module.bastion.pub_bastion_ip) : module.network.bastion_vip}"
 }
 
 output "bootstrap_ip" {
@@ -49,7 +49,7 @@ output "worker_ips" {
 output "etc_hosts_entries" {
   value = var.cluster_domain == "nip.io" || var.cluster_domain == "xip.io" || var.cluster_domain == "sslip.io" ? null : <<-EOF
 
-${module.network.bastion_vip == "" ? module.bastion.bastion_ip[0] : module.network.bastion_vip} api.${local.cluster_id}.${var.cluster_domain} console-openshift-console.apps.${local.cluster_id}.${var.cluster_domain} integrated-oauth-server-openshift-authentication.apps.${local.cluster_id}.${var.cluster_domain} oauth-openshift.apps.${local.cluster_id}.${var.cluster_domain} prometheus-k8s-openshift-monitoring.apps.${local.cluster_id}.${var.cluster_domain} grafana-openshift-monitoring.apps.${local.cluster_id}.${var.cluster_domain} example.apps.${local.cluster_id}.${var.cluster_domain}
+${module.network.bastion_vip == "" ? (var.pub_network_name == "" ? module.bastion.bastion_ip[0] : module.bastion.pub_bastion_ip) : module.network.bastion_vip} api.${local.cluster_id}.${var.cluster_domain} console-openshift-console.apps.${local.cluster_id}.${var.cluster_domain} integrated-oauth-server-openshift-authentication.apps.${local.cluster_id}.${var.cluster_domain} oauth-openshift.apps.${local.cluster_id}.${var.cluster_domain} prometheus-k8s-openshift-monitoring.apps.${local.cluster_id}.${var.cluster_domain} grafana-openshift-monitoring.apps.${local.cluster_id}.${var.cluster_domain} example.apps.${local.cluster_id}.${var.cluster_domain}
 EOF
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,10 @@ variable "worker" {
     # data_volume_count = 0 #Number of volumes to be attached to each worker node.
   }
 }
+variable "pub_network_name" {
+  description = "The name of the public network to be used for disconnected deploy operations"
+  default     = ""
+}
 
 variable "network_name" {
   description = "The name of the network to be used for deploy operations"


### PR DESCRIPTION
To configure the bastion node with a Public and a Private IP, a `pub_network_name` variable is created. This is required for setting up a disconnected cluster.