### PR TITLE
Update terraform required_version to ">= 1.5.0"

### DIFF
--- a/docs/automation_host_prereqs.md
+++ b/docs/automation_host_prereqs.md
@@ -19,7 +19,7 @@ Install the following packages on the automation host. Select the appropriate in
 
 ### Terraform
 
-**Terraform**: Please open the [link](https://www.terraform.io/downloads) for downloading the latest Terraform. For validating the version run `terraform version` command after install. Terraform version 1.2.0 and above is required.
+**Terraform**: Please open the [link](https://www.terraform.io/downloads) for downloading the latest Terraform. For validating the version run `terraform version` command after install. Terraform version 1.5.0 and above is required.
 
 Install Terraform and providers for Power environment:
 1. Download and install the latest Terraform binary for Linux/ppc64le from https://github.com/ppc64le-development/terraform-ppc64le/releases.

--- a/modules/1_bastion/versions.tf
+++ b/modules/1_bastion/versions.tf
@@ -37,5 +37,5 @@ terraform {
       version = "~> 0.10.0"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/2_network/versions.tf
+++ b/modules/2_network/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 1.32"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/3_helpernode/versions.tf
+++ b/modules/3_helpernode/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/4_nodes/4_1_bootstrapnode/versions.tf
+++ b/modules/4_nodes/4_1_bootstrapnode/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/4_nodes/4_2_masternodes/versions.tf
+++ b/modules/4_nodes/4_2_masternodes/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/4_nodes/4_3_workernodes/versions.tf
+++ b/modules/4_nodes/4_3_workernodes/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/5_install/5_1_installconfig/versions.tf
+++ b/modules/5_install/5_1_installconfig/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/5_install/5_2_bootstrapconfig/versions.tf
+++ b/modules/5_install/5_2_bootstrapconfig/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/5_install/5_3_bootstrapcomplete/versions.tf
+++ b/modules/5_install/5_3_bootstrapcomplete/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/modules/5_install/5_4_installcomplete/versions.tf
+++ b/modules/5_install/5_4_installcomplete/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -29,5 +29,5 @@ terraform {
       version = "~> 3.4"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
 }


### PR DESCRIPTION
Running `terraform apply -var-file=var.tfvars` led to error message
`Error: Error creating OpenStack networking client: You must provide exactly one of DomainID or DomainName to authenticate by Username` on terraform version 1.3.7
Updating to version 1.5.5 resolved this error.