### PR TITLE
OPENSHIFTP-754: OCP Automation: Support RHEL10/CentOS10

### DIFF
--- a/modules/1_bastion/bastion.tf
+++ b/modules/1_bastion/bastion.tf
@@ -222,7 +222,14 @@ else
     sudo subscription-manager register --org='${var.rhel_subscription_org}' --activationkey='${var.rhel_subscription_activationkey}' --force
 fi
 sudo subscription-manager refresh
-sudo subscription-manager attach --auto
+
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -lt 10 ]; then
+    echo "RHEL $RHEL_VERSION detected: Attaching subscriptions..."
+    sudo subscription-manager attach --auto
+else
+    echo "RHEL $RHEL_VERSION detected: Skipping 'attach' (SCA active)."
+fi
 
 EOF
     ]
@@ -373,7 +380,7 @@ resource "null_resource" "setup_nfs_disk" {
       "sudo mkfs.xfs /dev/${local.disk_config.disk_name}",
       "MY_DEV_UUID=$(sudo blkid -o export /dev/${local.disk_config.disk_name} | awk '/UUID/{ print }')",
       "echo \"$MY_DEV_UUID ${local.storage_path} xfs defaults 0 0\" | sudo tee -a /etc/fstab > /dev/null",
-      "sudo mount ${local.storage_path}",
+      "sudo mount ${local.storage_path}; sudo systemctl daemon-reload"
     ]
   }
 }

--- a/modules/1_bastion/templates/create_disk_link.sh
+++ b/modules/1_bastion/templates/create_disk_link.sh
@@ -14,7 +14,7 @@ else
     echo "Disk path is /dev/mapper/mpath*"
 fi
 
-for device in $(ls -1 $disk_path|egrep -v "[0-9]$"); do
+for device in $(ls -1 $disk_path | grep -E -v "[0-9]$"); do
     if [[ ! -b $device"1" ]]; then
         # Convert disk size to GB
         device_size=$(lsblk -b -dn -o SIZE $device | awk '{print $1/1073741824}')

--- a/modules/5_install/5_1_installconfig/installconfig.tf
+++ b/modules/5_install/5_1_installconfig/installconfig.tf
@@ -121,13 +121,21 @@ resource "null_resource" "pre_install" {
 
   # DHCP config for setting MTU; Since helpernode DHCP template does not support MTU setting
   provisioner "remote-exec" {
-    inline = [
-      # Set specified mtu for private interface.
-      "sudo ip link set dev $(ip r | grep \"${var.cidr} dev\" | awk '{print $3}') mtu ${var.private_network_mtu}",
-      "echo MTU=${var.private_network_mtu} | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-$(ip r | grep ${var.cidr} | awk '{print $3}')",
+    inline = [<<-EOF
+      # Set specified MTU for private interface;
+      sudo ip link set dev $(ip r | grep "${var.cidr} dev" | awk '{print $3}') mtu ${var.private_network_mtu}
+      echo MTU=${var.private_network_mtu} | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-$(ip r | grep ${var.cidr} | awk '{print $3}')
       # DHCP config for setting MTU;
-      "sed -i.mtubak '/option routers/i option interface-mtu ${var.private_network_mtu};' /etc/dhcp/dhcpd.conf",
-      "sudo systemctl restart dhcpd.service"
+      RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+      if [ "$RHEL_VERSION" -lt 10 ]; then
+          sudo sed -i.mtubak '/option routers/i option interface-mtu ${var.private_network_mtu};' /etc/dhcp/dhcpd.conf
+          sudo systemctl restart dhcpd.service
+      else
+          sudo jq '.Dhcp4["option-data"] |= [{"name":"interface-mtu","data":"${var.private_network_mtu}"}] + .' /etc/kea/kea-dhcp4.conf > /tmp/kea.conf
+          sudo mv /tmp/kea.conf /etc/kea/kea-dhcp4.conf
+          sudo systemctl restart kea-dhcp4.service
+      fi
+EOF
     ]
   }
 }


### PR DESCRIPTION
Changes made for *[OPENSHIFTP-754](https://jsw.ibm.com/browse/OPENSHIFTP-754)*: OCP Automation: Support RHEL10/CentOS10
  
  - Adds NFS disk support changes
  - Handle subscription-manager attach differences.
  - Added support for kea-dhcp4

Verification done with RHEL10, RHEL9 & CentOS10 cluster deployment.

ocp4-helpernode: https://github.com/redhat-cop/ocp4-helpernode/pull/338
ocp4-playbooks: https://github.com/ocp-power-automation/ocp4-playbooks/pull/207

CC: @prb112 